### PR TITLE
Add --ffmpeg-location to ValidOptions list

### DIFF
--- a/src/Ytdlp.NET/Ytdlp.cs
+++ b/src/Ytdlp.NET/Ytdlp.cs
@@ -74,7 +74,8 @@ public sealed class Ytdlp
 
         // Others (use with caution depending on context)
         "--config-location", "--write-video", "--write-audio", "--no-post-overwrites",
-        "--break-on-existing", "--break-per-input", "--windows-filenames", "--restrict-filenames"
+        "--break-on-existing", "--break-per-input", "--windows-filenames", "--restrict-filenames",
+        "--ffmpeg-location"
     };
 
     public Ytdlp(string ytDlpPath = "yt-dlp", ILogger? logger = null)


### PR DESCRIPTION
I am writing an app where I don't want to have to install --ffmpeg but instead want to bundle it in my app.

I am able to use the AddCustomCommand method to specify the ffmpeg location, but since --ffmpeg-location isn't in the valid list of options, an error is raised instead.

This is a merge request to add --ffmpeg-location as a valid command.