### PR TITLE
Improve process termination, progress parsing, and docs

### DIFF
--- a/src/Ytdlp.NET.Console/Program.cs
+++ b/src/Ytdlp.NET.Console/Program.cs
@@ -19,20 +19,20 @@ internal class Program
             .WithFFmpegLocation("tools");
 
         // Run all demos/tests sequentially
-        await TestGetVersionAsync(baseYtdlp);
-        await TestUpdateAsync(baseYtdlp);
+        //await TestGetVersionAsync(baseYtdlp);
+        //await TestUpdateAsync(baseYtdlp);
 
-        await TestGetFormatsAsync(baseYtdlp);
-        await TestGetMetadataAsync(baseYtdlp);
-        await TestGetLiteMetadataAsync(baseYtdlp);
-        await TestGetTitleAsync(baseYtdlp);
+        //await TestGetFormatsAsync(baseYtdlp);
+        //await TestGetMetadataAsync(baseYtdlp);
+        //await TestGetLiteMetadataAsync(baseYtdlp);
+        //await TestGetTitleAsync(baseYtdlp);
 
         await TestDownloadVideoAsync(baseYtdlp);
-        await TestDownloadAudioAsync(baseYtdlp);
-        await TestBatchDownloadAsync(baseYtdlp);
-        await TestSponsorBlockAsync(baseYtdlp);
-        await TestConcurrentFragmentsAsync(baseYtdlp);
-        await TestCancellationAsync(baseYtdlp);
+        //await TestDownloadAudioAsync(baseYtdlp);
+        //await TestBatchDownloadAsync(baseYtdlp);
+        //await TestSponsorBlockAsync(baseYtdlp);
+        //await TestConcurrentFragmentsAsync(baseYtdlp);
+        //await TestCancellationAsync(baseYtdlp);
 
         var lists = await baseYtdlp.ExtractorsAsync();
 
@@ -104,10 +104,12 @@ internal class Program
         var stopwatch = Stopwatch.StartNew();
 
         Console.WriteLine("\nTest 4: Fetching detailed metedata...");
-
+        var token = new CancellationTokenSource().Token; // In real use, you might want to cancel if it takes too long
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(90));
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token, timeoutCts.Token);
         var url1 = "https://www.youtube.com/watch?v=983bBbJx0Mk&list=RD983bBbJx0Mk&start_radio=1&pp=ygUFc29uZ3OgBwE%3D"; //playlist
         var url2 = "https://www.youtube.com/watch?v=ZGnQH0LN_98"; // video
-        var metadata = await ytdlp.GetMetadataAsync(url1);
+        var metadata = await ytdlp.GetMetadataAsync(url2, linkedCts.Token);
         stopwatch.Stop(); // stop timer
 
         Console.WriteLine($"Detailed metedata took {stopwatch.Elapsed.TotalSeconds:F3} seconds");
@@ -157,7 +159,7 @@ internal class Program
     private static async Task TestDownloadVideoAsync(Ytdlp ytdlpBase)
     {
         Console.WriteLine("\nTest 6: Downloading a video...");
-        var url = "https://www.youtube.com/watch?v=3pecPwPIFIc&pp=ugUEEgJtbA%3D%3D";
+        var url = "https://www.youtube.com/watch?v=89-i4aPOMrc";
 
         var ytdlp = ytdlpBase
             .With720pOrBest()
@@ -170,7 +172,7 @@ internal class Program
 
         // Subscribe to events
         ytdlp.OnProgressDownload += (sender, args) =>
-            Console.WriteLine($"Progress: {args.Percent:F2}% - {args.Speed} - ETA {args.ETA}");
+            Console.WriteLine($"Progress: {args.Percent:F2}% - {args.Speed} - ETA {args.ETA} - Size {args.Size}");
 
         ytdlp.OnCompleteDownload += (sender, message) =>
             Console.WriteLine($"Download complete: {message}");
@@ -240,6 +242,9 @@ internal class Program
             .WithOutputTemplate("%(title)s.%(ext)s")
             .WithOutputFolder("./downloads/concurrent");
 
+        ytdlp.OnProgressDownload += (sender, args) =>
+           Console.WriteLine($"Progress: {args.Percent:F2}% - {args.Speed} - ETA {args.ETA} - FRA {args.Fragments}");
+
         await ytdlp.DownloadAsync(url);
     }
 
@@ -250,11 +255,22 @@ internal class Program
         var url = "https://www.youtube.com/watch?v=zGlwuHqGVIA";  // A longer video
 
         var cts = new CancellationTokenSource();
+
         var downloadTask = ytdlp
             .WithFormat("b")
             .WithOutputTemplate("%(title)s.%(ext)s")
             .WithOutputFolder("./downloads/cancel")
             .DownloadAsync(url, cts.Token);
+
+        ytdlp.OnCommandCompleted += (sender, args) =>
+        {
+            if (args.Success)
+                Console.WriteLine("Download completed successfully.");
+            else if (args.Message.Contains("cancelled", StringComparison.OrdinalIgnoreCase))
+                Console.WriteLine("Download was cancelled.");
+            else
+                Console.WriteLine($"Download failed: {args.Message}");
+        };
 
         // Simulate cancel after 20 seconds
         await Task.Delay(20000);
@@ -262,6 +278,8 @@ internal class Program
 
         try
         {
+
+
             await downloadTask;
         }
         catch (OperationCanceledException)

--- a/src/Ytdlp.NET/Core/DownloadRunner.cs
+++ b/src/Ytdlp.NET/Core/DownloadRunner.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics;
-
-namespace ManuHub.Ytdlp.NET.Core;
+﻿namespace ManuHub.Ytdlp.NET.Core;
 
 public sealed class DownloadRunner
 {
@@ -88,9 +86,7 @@ public sealed class DownloadRunner
 
             // Ensure process is dead
             if (!process.HasExited)
-            {
-                ProcessFactory.SafeKill(process, _logger);
-            }
+                ProcessFactory.SafeKill(process);
 
             try
             {
@@ -98,7 +94,8 @@ public sealed class DownloadRunner
             }
             catch (OperationCanceledException)
             {
-                ProcessFactory.SafeKill(process, _logger);
+                if (!process.HasExited)
+                    ProcessFactory.SafeKill(process);
             }
 
             var success = process.ExitCode == 0 && !ct.IsCancellationRequested;

--- a/src/Ytdlp.NET/Core/ProcessFactory.cs
+++ b/src/Ytdlp.NET/Core/ProcessFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using ManuHub.Ytdlp.NET.Extensions;
+using System.Diagnostics;
 using System.Text;
 
 namespace ManuHub.Ytdlp.NET.Core;
@@ -24,7 +25,6 @@ public sealed class ProcessFactory
             FileName = _ytdlpPath,
             Arguments = arguments,
 
-            // Must for async/event-based reading
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             RedirectStandardInput = true,
@@ -75,18 +75,15 @@ public sealed class ProcessFactory
             if (process.HasExited)
                 return;
 
-            // Close streams first → prevents ReadLine hang
-            try { process.StandardOutput?.Close(); } catch { }
-            try { process.StandardError?.Close(); } catch { }
-            try { process.StandardInput?.Close(); } catch { }
+            process.KillTree();
 
-            process.Kill(entireProcessTree: true);
-
-            logger?.Log(LogType.Info, "Process killed (entire tree)");
+            if(logger != null)
+                logger.Log(LogType.Info, "Process killed (entire tree)");
         }
         catch (Exception ex)
         {
-            logger?.Log(LogType.Error, $"Failed to kill process: {ex.Message}");
+            if(logger != null)
+                logger.Log(LogType.Error, $"Failed to kill process: {ex.Message}");
         }
     }
 }

--- a/src/Ytdlp.NET/Extensions/ProcessExtensions.cs
+++ b/src/Ytdlp.NET/Extensions/ProcessExtensions.cs
@@ -1,0 +1,109 @@
+﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace ManuHub.Ytdlp.NET.Extensions;
+
+/// <summary>
+/// Process extensions for killing full process tree.
+/// </summary>
+internal static class ProcessExtensions
+{
+    private static readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(30);
+
+    public static void KillTree(this Process process)
+    {
+        process.KillTree(_defaultTimeout);
+    }
+
+    public static void KillTree(this Process process, TimeSpan timeout)
+    {
+        string stdout;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            RunProcessAndWaitForExit(
+                "taskkill",
+                $"/T /F /PID {process.Id}",
+                timeout,
+                out stdout);
+        }
+        else
+        {
+            var children = new HashSet<int>();
+            GetAllChildIdsUnix(process.Id, children, timeout);
+            foreach (var childId in children)
+            {
+                KillProcessUnix(childId, timeout);
+            }
+            KillProcessUnix(process.Id, timeout);
+        }
+    }
+
+    private static void GetAllChildIdsUnix(int parentId, ISet<int> children, TimeSpan timeout)
+    {
+        string stdout;
+        var exitCode = RunProcessAndWaitForExit(
+            "pgrep",
+            $"-P {parentId}",
+            timeout,
+            out stdout);
+
+        if (exitCode == 0 && !string.IsNullOrEmpty(stdout))
+        {
+            using (var reader = new StringReader(stdout))
+            {
+                while (true)
+                {
+                    var text = reader.ReadLine();
+                    if (text == null)
+                    {
+                        return;
+                    }
+
+                    int id;
+                    if (int.TryParse(text, out id))
+                    {
+                        children.Add(id);
+                        GetAllChildIdsUnix(id, children, timeout);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void KillProcessUnix(int processId, TimeSpan timeout)
+    {
+        string stdout;
+        RunProcessAndWaitForExit(
+            "kill",
+            $"-TERM {processId}",
+            timeout,
+            out stdout);
+    }
+
+    private static int RunProcessAndWaitForExit(string fileName, string arguments, TimeSpan timeout, out string stdout)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        var process = Process.Start(startInfo);
+
+        stdout = null;
+        if (process.WaitForExit((int)timeout.TotalMilliseconds))
+        {
+            stdout = process.StandardOutput.ReadToEnd();
+        }
+        else
+        {
+            process.Kill();
+        }
+
+        return process.ExitCode;
+    }
+}
+

--- a/src/Ytdlp.NET/Parsing/ProgressParser.cs
+++ b/src/Ytdlp.NET/Parsing/ProgressParser.cs
@@ -183,7 +183,7 @@ public sealed class ProgressParser
     {
         // Existing logic unchanged
         string percentString = match.Groups["percent"].Value;
-        string sizeString = match.Groups["size"].Value;
+        string sizeString = match.Groups["total"].Value;
         string speedString = match.Groups["speed"].Value;
         string etaString = match.Groups["eta"].Value;
 

--- a/src/Ytdlp.NET/Parsing/RegexPatterns.cs
+++ b/src/Ytdlp.NET/Parsing/RegexPatterns.cs
@@ -17,7 +17,8 @@ internal static class RegexPatterns
     public const string DownloadDestination = @"\[download\]\s*Destination:\s*(?<path>.+)";
     public const string ResumeDownload = @"\[download\]\s*Resuming download at byte\s*(?<byte>\d+)";
     public const string DownloadAlreadyDownloaded = @"\[download\]\s*(?<path>[^\n]+?)\s*has already been downloaded";
-    public const string DownloadProgress = @"\[download\]\s*(?<percent>\d+\.\d+)%\s*of\s*(?<size>[^\s]+)\s*at\s*(?<speed>[^\s]+)\s*ETA\s*(?<eta>[^\s]+)";
+    public const string DownloadProgress = @"\[download\]\s+(?:(?<percent>[\d\.]+)%(?:\s+of\s+\~?\s*(?<total>[\d\.\w]+))?\s+at\s+(?:(?<speed>[\d\.\w]+\/s)|[\w\s]+)\s+ETA\s(?<eta>[\d\:]+))?";
+                                         //@"\[download\]\s*(?<percent>\d+\.\d+)%\s*of\s*(?<size>[^\s]+)\s*at\s*(?<speed>[^\s]+)\s*ETA\s*(?<eta>[^\s]+)";
     public const string DownloadProgressWithFrag = @"\[download\]\s*(?<percent>\d+\.\d+)%\s*of\s*(~?\s*(?<size>[^\s]+))\s*at\s*(?<speed>[^\s]+)\s*ETA\s*(?<eta>[^\s]+)\s*\(frag\s*(?<frag>\d+/\d+)\)";
     public const string DownloadProgressComplete = @"\[download\]\s*(?<percent>100(?:\.0)?)%\s*of\s*(?<size>[^\s]+)\s*at\s*(?<speed>[^\s]+|Unknown)\s*ETA\s*(?<eta>[^\s]+|Unknown)";
     public const string UnknownError = @"\[download\]\s*Unknown error";
@@ -26,8 +27,6 @@ internal static class RegexPatterns
     public const string ExtractingMetadata = @"\[(?<source>[^\]]+)\]\s*(?<id>[^\s:]+):\s*Extracting metadata";
     public const string SpecificError = @"\[(?<source>[^\]]+)\]\s*(?<id>[^\s:]+):\s*ERROR:\s*(?<error>.+)";
     public const string DownloadingSubtitles = @"\[info\]\s*Downloading subtitles:\s*(?<language>[^\s]+)";
-
-    // ───────────── New / Enhanced Patterns for v2.0 ─────────────
 
     // More reliable merger success detection (variation of "successfully merged")
     public const string MergerSuccess = @"(?:has been successfully merged|merged formats successfully)";

--- a/src/Ytdlp.NET/README.md
+++ b/src/Ytdlp.NET/README.md
@@ -239,7 +239,7 @@ await ytdlp.DownloadBatchAsync(urls, maxConcurrency: 3);
 * `.WithJsRuntime(Runtime runtime, string runtimePath)`
 * `.WithNoJsRuntime()`
 * `.WithFlatPlaylist()`
-* ` WithLiveFromStart()`
+* `.WithLiveFromStart()`
 * `.WithWaitForVideo(TimeSpan? maxWait = null)`
 * `.WithMarkWatched()`   
 
@@ -436,8 +436,15 @@ await ytdlp.DownloadAsync(url);
 | `SetFFMpegLocation()` | `WithFFmpegLocation()` |
 | `ExtractAudio()`      | `WithExtractAudio()`   |
 | `UseProxy()`          | `WithProxy()`          |
+| `AddCustomCommand()`  | `AddFlag(string flag)` or `AddOption(string key, string value)` |
 
 ---
+
+## Custom commands
+```csharp
+AddFlag("--no-check-certificate");
+AddOption("--external-downloader", "aria2c");
+```
 
 ## Important behavior changes
 

--- a/src/Ytdlp.NET/Ytdlp.NET.csproj
+++ b/src/Ytdlp.NET/Ytdlp.NET.csproj
@@ -7,7 +7,7 @@
 		<PackageId>Ytdlp.NET</PackageId>
 		<AssemblyName>Ytdlp.NET</AssemblyName>
 		<RootNamespace>ManuHub.Ytdlp.NET</RootNamespace>
-		<Version>3.0.1</Version>
+		<Version>3.0.2</Version>
 		<Authors>ManuHub Manojbabu</Authors>
 		<PackageDescription>A .NET wrapper for yt-dlp with advanced features like concurrent downloads, SponsorBlock, and improved format parsing</PackageDescription>
 		<Copyright>© 2025-2026 ManuHub. Allrights researved</Copyright>

--- a/src/Ytdlp.NET/Ytdlp.cs
+++ b/src/Ytdlp.NET/Ytdlp.cs
@@ -1,5 +1,6 @@
 ﻿using ManuHub.Ytdlp.NET.Core;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -1365,6 +1366,9 @@ public sealed class Ytdlp : IAsyncDisposable
                 $"--quiet " +
                 $"--no-warnings " +
                 $"{Quote(url)}";
+
+            if(ct.IsCancellationRequested)
+                Debug.WriteLine("Cancellation requested before starting the process.");
 
             var json = await Probe().RunAsync(arguments, ct, tuneProcess, bufferKb);
 


### PR DESCRIPTION
- Add ProcessExtensions.KillTree for reliable cross-platform process tree termination; update ProcessFactory to use it
- Enhance download progress regex and parsing for better accuracy
- Improve cancellation handling and add pre-checks in Ytdlp
- Update demo/test code: comment out most tests, improve progress/cancellation output, change test URLs
- Document AddFlag/AddOption in README, fix minor typos, add table entry
- Bump version to 3.0.2