### PR TITLE
Refactor API: string formats, custom flags, doc overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ await ytdlp.DownloadBatchAsync(urls, maxConcurrency: 3);
 | `OnProgressDownload`       | Download progress        |
 | `OnProgressMessage`        | Informational messages   |
 | `OnCompleteDownload`       | File finished            |
+| `OnPostProcessingStart`    | Post‑processing start    |
 | `OnPostProcessingComplete` | Post‑processing finished |
 | `OnOutputMessage`          | Raw output line          |
 | `OnErrorMessage`           | Error message            |
@@ -206,61 +207,154 @@ await ytdlp.DownloadBatchAsync(urls, maxConcurrency: 3);
 
 # 🔧 Fluent API Methods
 
-### Output
+### General Options
+* `.WithIgnoreErrors()`
+* `.WithAbortOnError()`
+* `.WithIgnoreConfig()`
+* `.WithConfigLocations(string path)`
+* `.WithPluginDirs(string path)`
+* `.WithNoPluginDirs(string path)`
+* `.WithJsRuntime(Runtime runtime, string runtimePath)`
+* `.WithNoJsRuntime()`
+* `.WithFlatPlaylist()`
+* `.WithLiveFromStart()`
+* `.WithWaitForVideo(TimeSpan? maxWait = null)`
+* `.WithMarkWatched()`   
 
-```
-WithOutputFolder()
-WithTempFolder()
-WithHomeFolder()
-WithOutputTemplate()
-WithFFmpegLocation()
-```
+### Network Options
+* `.WithProxy(string? proxy)`
+* `.WithSocketTimeout(TimeSpan timeout)`
+* `.WithForceIpv4()`
+* `.WithForceIpv6()`
+* `.WithEnableFileUrls()`
 
-### Formats
+### Geo-restriction Options
+* `.WithGeoVerificationProxy(string url)`
+* `.WithGeoBypassCountry(string countryCode)`
 
-```
-WithFormat()
-With720pOrBest()
-WithExtractAudio()
-```
+### Video Selection
+* `.WithPlaylistItems(string items)`
+* `.WithMinFileSize(string size)`
+* `.WithMaxFileSize(string size)`
+* `.WithDate(string date)`
+* `.WithDateBefore(string date)`
+* `.WithDateAfter(string date)`
+* `.WithMatchFilter(string filterExpression)`
+* `.WithNoPlaylist()`
+* `.WithYesPlaylist()`
+* `.WithAgeLimit(int years)`
+* `.WithDownloadArchive(string archivePath = "archive.txt")`
+* `.WithMaxDownloads(int count)`
+* `.WithBreakOnExisting()`
 
-### Metadata
+### Download Options
+* `.WithConcurrentFragments(int count = 8)`
+* `.WithLimitRate(string rate)`
+* `.WithThrottledRate(string rate)`
+* `.WithRetries(int maxRetries)`
+* `.WithFileAccessRetries(int maxRetries)`
+* `.WithFragmentRetries(int retries)`
+* `.WithSkipUnavailableFragments()`
+* `.WithAbortOnUnavailableFragments()`
+* `.WithKeepFragments()`
+* `.WithBufferSize(string size)`
+* `.WithNoResizeBuffer()`
+* `.WithPlaylistRandom()`
+* `.WithHlsUseMpegts()`
+* `.WithNoHlsUseMpegts()`
+* `.WithDownloadSections(string regex)`
 
-```
-GetMetadataAsync()
-GetBestAudioFormatIdAsync()
-GetBestVideoFormatIdAsync()
-GetAvailableFormatsAsync()
-```
+### Filesystem Options
+* `.WithHomeFolder(string path)`
+* `.WithTempFolder(string path)`
+* `.WithOutputFolder(string path)`
+* `.WithFFmpegLocation(string path)`
+* `.WithOutputTemplate(string template)`
+* `.WithRestrictFilenames()`
+* `.WithWindowsFilenames()`
+* `.WithTrimFilenames(int length)`
+* `.WithNoOverwrites()`
+* `.WithForceOverwrites()`
+* `.WithNoContinue()`
+* `.WithNoPart()`
+* `.WithMtime()`
+* `.WithWriteDescription()`
+* `.WithWriteInfoJson()`
+* `.WithNoWritePlaylistMetafiles()`
+* `.WithNoCleanInfoJson()`
+* `.WriteComments()`
+* `.WithNoWriteComments()`
+* `.WithLoadInfoJson(string path)`
+* `.WithCookiesFile(string path)`
+* `.WithCookiesFromBrowser(string browser)`
+* `.WithNoCacheDir()`
+* `.WithRemoveCacheDir()`
 
-### Features
+### Thumbnail Options
+* `.WithThumbnails(bool allSizes = false)`
 
-```
-WithEmbedMetadata()
-WithEmbedThumbnail()
-WithEmbedSubtitles()
-WithSubtitles()
-WithConcurrentFragments()
-WithSponsorblockRemove()
-```
+### Verbosity and Simulation Options
+* `.WithQuiet()`
+* `.WithNoWarnings()`
+* `.WithSimulate()`
+* `.WithNoSimulate()`
+* `.WithSkipDownload()`
+* `.WithVerbose()`
 
-### Network
+### Workgrounds
+* `.WithAddHeader(string header, string value)`
+* `.WithSleepInterval(double seconds, double? maxSeconds = null)`
+* `.WithSleepSubtitles(double seconds)`
 
-```
-WithProxy()
-WithCookiesFile()
-WithCookiesFromBrowser()
-```
+### Video Format Options
+* `.WithFormat(string format)`
+* `.WithMergeOutputFormat(string format)`
 
-### Advanced
+### Subtitle Options
+* `.WithSubtitles(string languages = "all", bool auto = false)`
 
-```
-AddFlag()
-AddOption()
-AddCustomCommand()
-```
+### Authentication Options
+* `.WithAuthentication(string username, string password)`
+* `.WithTwoFactor(string code)`
+
+### Post-Processing Options
+* `.WithExtractAudio(string format, int quality = 5)`
+* `.WithRemuxVideo(string format)` usage 'mp4' or 'mp4>mkv'
+* `.WithRecodeVideo(string format, string? videoCodec = null, string? audioCodec = null)`
+* `.WithPostprocessorArgs(PostProcessors postprocessor, string args)`
+* `.WithKeepVideo()`
+* `.WithNoPostOverwrites()`
+* `.WithEmbedSubtitles(string languages = "all", string? convertTo = null)`
+* `.WithEmbedThumbnail()`
+* `.WithEmbedMetadata()`
+* `.WithEmbedChapters()`
+* `.WithEmbedInfoJson()`
+* `.WithNoEmbedInfoJson()`
+* `.WithReplaceInMetadata(string field, string regex, string replacement)`
+* `.WithConcatPlaylist(string policy = "always")`
+* `.WithFFmpegLocation(string? ffmpegPath)`
+* `.WithConvertThumbnails(string format = "jpg")`
+* `.WithForceKeyframesAtCuts()`
+
+### SponsorBlock Options
+* `.WithSponsorblockMark(string categories = "all")`
+* `.WithSponsorblockRemove(string categories = "all")`
+* `.WithNoSponsorblock()`
+
+### Advanced Options
+* `.AddFlag(string flag)`
+* `.AddOption(string key, string value)`
+
+### Downloaders
+* `.WithExternalDownloader(string downloaderName, string? downloaderArgs = null)`
+* `.WithAria2(int connections = 16)`
+* `.WithHlsNative()`
+* `.WithFfmpegAsLiveDownloader(string? extraFfmpegArgs = null)`
+
+AND MORE ...
 
 ---
+
 
 # 🔄 Upgrade Guide (v2 → v3)
 
@@ -306,8 +400,15 @@ await ytdlp.DownloadAsync(url);
 | `SetFFMpegLocation()` | `WithFFmpegLocation()` |
 | `ExtractAudio()`      | `WithExtractAudio()`   |
 | `UseProxy()`          | `WithProxy()`          |
+| `AddCustomCommand()`  | `AddFlag(string flag)` or `AddOption(string key, string value)` |
 
 ---
+
+## Custom commands
+```csharp
+AddFlag("--no-check-certificate");
+AddOption("--external-downloader", "aria2c");
+```
 
 ## Important behavior changes
 

--- a/src/Ytdlp.NET.Console/Program.cs
+++ b/src/Ytdlp.NET.Console/Program.cs
@@ -181,10 +181,12 @@ internal class Program
         var url = "https://www.youtube.com/watch?v=89-i4aPOMrc"; //"https://www.dailymotion.com/video/xa3ron2"; 
 
         var ytdlp = ytdlpBase
-            .WithFormat("95+ba/b")
+            .WithFormat("ba/b")
+            .WithExtractAudio(AudioFormat.Mp3)
             .WithConcurrentFragments(8)
-            .WithHomeFolder("./downloads")
-            .WithTempFolder("./downloads/temp")
+            .WithOutputFolder("./downloads")
+            //.WithHomeFolder("./downloads")
+            //.WithTempFolder("./downloads/temp")
             .WithOutputTemplate("%(title)s.%(ext)s");
             //.WithEmbedMetadata()
             //.WithEmbedThumbnail()
@@ -215,7 +217,7 @@ internal class Program
 
         Console.WriteLine(ytdlp.Preview(url));
 
-        await ytdlp.DownloadAsync(url);
+       await ytdlp.DownloadAsync(url);
     }
 
     private static async Task TestDownloadAudioAsync(Ytdlp ytdlpBase)

--- a/src/Ytdlp.NET/Parsing/ProgressParser.cs
+++ b/src/Ytdlp.NET/Parsing/ProgressParser.cs
@@ -102,19 +102,13 @@ public sealed class ProgressParser
     {
         if (_isDownloadCompleted) return;
 
-        // Existing logic unchanged
         string percentString = match.Groups["percent"].Value;
         string sizeString = match.Groups["total"].Value;
         string speedString = match.Groups["speed"].Value;
         string etaString = match.Groups["eta"].Value;
 
         if (!double.TryParse(percentString.Replace("%", ""), out double percent))
-            percent = 0;
-
-        if (percent >= 99.0 && !_isDownloadCompleted)
-        {
-            HandleDownloadProgressComplete(match);
-        }
+            percent = 0;       
 
         var args = new DownloadProgressEventArgs
         {
@@ -127,13 +121,17 @@ public sealed class ProgressParser
 
         LogAndNotify(LogType.Info, args.Message);
         OnProgressDownload?.Invoke(this, args);
+
+        if (percent >= 99.0 && !_isDownloadCompleted)
+        {
+            HandleDownloadProgressComplete(match);
+        }
     }
 
     private void HandleDownloadProgressWithFrag(Match match)
     {
         if (_isDownloadCompleted) return;
 
-        // Existing + prevent premature complete if fragments remain
         string percentString = match.Groups["percent"].Value;
         string sizeString = match.Groups["size"].Value;
         string speedString = match.Groups["speed"].Value;
@@ -155,8 +153,6 @@ public sealed class ProgressParser
 
         LogAndNotify(LogType.Info, args.Message);
         OnProgressDownload?.Invoke(this, args);
-
-        Debug.WriteLine($"DEBUG: Progress with frag → percent: {percent}, size: {sizeString}, speed: {speedString}, eta: {etaString}, frag: {fragString}");
 
         // Only trigger complete if really done (avoid false 100% on fragment level)
         if (percent >= 99.0 && IsFinalFragment(fragString) && !_isDownloadCompleted)
@@ -229,7 +225,7 @@ public sealed class ProgressParser
 
         _postProcessStepCount++;
 
-        // Better group extraction
+        // Extract processor and action safely
         string processor = match.Groups["processor"].Success
             ? match.Groups["processor"].Value.Trim()
             : "PostProcessor";
@@ -241,11 +237,11 @@ public sealed class ProgressParser
         var message = $"[{processor}] {action}";
         LogAndNotify(LogType.Info, $"Post-processing [{_postProcessStepCount}]: {message}");
 
-        // === KEY CHANGE: Only complete on MoveFiles or after many steps ===
+        // Trigger completion when we hit the real last step (MoveFiles is usually the final one)
         bool isFinalStep =
             processor.Equals("MoveFiles", StringComparison.OrdinalIgnoreCase) ||
             action.Contains("Moving file", StringComparison.OrdinalIgnoreCase) ||
-            _postProcessStepCount >= 8;   // safety net
+            _postProcessStepCount >= 10;  // safety net for unusual cases
 
         if (isFinalStep)
         {
@@ -259,13 +255,6 @@ public sealed class ProgressParser
             // Reset flags so next download starts fresh
             Reset();
         }
-    }
-
-    private void HandleSponsorBlock(Match match)
-    {
-        var action = match.Groups["action"].Value.Trim();
-        var details = match.Groups["details"].Success ? match.Groups["details"].Value.Trim() : "";
-        LogAndNotify(LogType.Info, $"SponsorBlock {action}{(string.IsNullOrEmpty(details) ? "" : $": {details}")}");
     }
 
     private void HandleUnknownOutput(string output)

--- a/src/Ytdlp.NET/Parsing/RegexPatterns.cs
+++ b/src/Ytdlp.NET/Parsing/RegexPatterns.cs
@@ -7,7 +7,7 @@ internal static class RegexPatterns
     public const string ResumeDownload = @"\[download\]\s*Resuming download at byte\s*(?<byte>\d+)";
     public const string DownloadAlreadyDownloaded = @"\[download\]\s*(?<path>[^\n]+?)\s*has already been downloaded";
     public const string DownloadProgress = @"\[download\]\s+(?:(?<percent>[\d\.]+)%(?:\s+of\s+\~?\s*(?<total>[\d\.\w]+))?\s+at\s+(?:(?<speed>[\d\.\w]+\/s)|[\w\s]+)\s+ETA\s(?<eta>[\d\:]+))?";
-                                         //@"\[download\]\s*(?<percent>\d+\.\d+)%\s*of\s*(?<size>[^\s]+)\s*at\s*(?<speed>[^\s]+)\s*ETA\s*(?<eta>[^\s]+)";
+    //@"\[download\]\s*(?<percent>\d+\.\d+)%\s*of\s*(?<size>[^\s]+)\s*at\s*(?<speed>[^\s]+)\s*ETA\s*(?<eta>[^\s]+)";
     public const string DownloadProgressWithFrag = @"\[download\]\s*(?<percent>\d+\.\d+)%\s*of\s*(~?\s*(?<size>[^\s]+))\s*at\s*(?<speed>[^\s]+)\s*ETA\s*(?<eta>[^\s]+)\s*\(frag\s*(?<frag>\d+/\d+)\)";
     public const string DownloadProgressComplete = @"\[download\]\s*(?<percent>100(?:\.0)?)%\s*of\s*(?<size>[^\s]+)\s*at\s*(?<speed>[^\s]+|Unknown)\s*ETA\s*(?<eta>[^\s]+|Unknown)";
     public const string UnknownError = @"\[download\]\s*Unknown error";
@@ -32,5 +32,6 @@ internal static class RegexPatterns
     public const string MoveFiles = @"\[MoveFiles\]\s*(?<action>.+)";
 
     // Generic fallback for any unknown post-processor
-    public const string PostProcessorGeneric = @"\[(?<processor>FixupM3u8|VideoRemuxer|Metadata|ThumbnailsConvertor|EmbedThumbnail|MoveFiles|Merger|ffmpeg|ConvertSubs|SponsorBlock)\]\s*(?<action>.+)";
+    public const string PostProcessorGeneric =
+        @"\[(?<processor>Merger|ModifyChapters|SplitChapters|ExtractAudio|VideoRemuxer|VideoConvertor|Metadata|EmbedSubtitle|EmbedThumbnail|SubtitlesConvertor|ThumbnailsConvertor|FixupStretched|FixupM4a|FixupM3u8|FixupTimestamp|FixupDuration|MoveFiles|ffmpeg|ConvertSubs|SponsorBlock)\]\s*(?<action>.+)";
 }

--- a/src/Ytdlp.NET/README.md
+++ b/src/Ytdlp.NET/README.md
@@ -146,8 +146,9 @@ await ytdlp.DownloadAsync("https://www.youtube.com/watch?v=RGg-Qx1rL9U");
 
 ```csharp
 await using var ytdlp = new Ytdlp("tools\\yt-dlp.exe")
-    .WithExtractAudio("mp3")
+    .WithExtractAudio(AudioFormat.Mp3, 5)
     .WithOutputFolder("./audio")
+    .WithEmbedThumbnail()
     .WithEmbedMetadata();
 
 await ytdlp.DownloadAsync("https://www.youtube.com/watch?v=RGg-Qx1rL9U");
@@ -340,9 +341,9 @@ await ytdlp.DownloadBatchAsync(urls, maxConcurrency: 3);
 * `.WithTwoFactor(string code)`
 
 ### Post-Processing Options
-* `.WithExtractAudio(string format = "mp3", int quality = 5)`
-* `.WithRemuxVideo(MediaFormat format = MediaFormat.Mp4)`
-* `.WithRecodeVideo(MediaFormat format = MediaFormat.Mp4, string? videoCodec = null, string? audioCodec = null)`
+* `.WithExtractAudio(string format, int quality = 5)`
+* `.WithRemuxVideo(string format)` usage 'mp4' or 'mp4>mkv'
+* `.WithRecodeVideo(string format, string? videoCodec = null, string? audioCodec = null)`
 * `.WithPostprocessorArgs(PostProcessors postprocessor, string args)`
 * `.WithKeepVideo()`
 * `.WithNoPostOverwrites()`
@@ -367,7 +368,6 @@ await ytdlp.DownloadBatchAsync(urls, maxConcurrency: 3);
 * `.AddFlag(string flag)`
 * `.AddOption(string key, string value)`
 
-
 ### Downloaders
 * `.WithExternalDownloader(string downloaderName, string? downloaderArgs = null)`
 * `.WithAria2(int connections = 16)`
@@ -384,7 +384,8 @@ AND MORE ...
 ytdlp.OnProgressDownload += (s, e) => Console.WriteLine($"Progress: {e.Percent:F2}%");
 ytdlp.OnProgressMessage += (s, msg) => Console.WriteLine(msg);
 ytdlp.OnCompleteDownload += (s, msg) => Console.WriteLine($"Done: {msg}");
-ytdlp.OnPostProcessingComplete += (s, msg) => Console.WriteLine($"Post-processing: {msg}");
+ytdlp.OnPostProcessingStart += (s, msg) => Console.WriteLine($"Post-processing-start: {msg}")
+ytdlp.OnPostProcessingComplete += (s, msg) => Console.WriteLine($"Post-processing-complete: {msg}");
 ytdlp.OnErrorMessage += (s, err) => Console.WriteLine($"Error: {err}");
 ytdlp.OnOutputMessage += (s, msg) => Console.WriteLine(msg);
 ytdlp.OnCommandCompleted += (s, e) => Console.WriteLine($"Command finished: {e.Command}");

--- a/src/Ytdlp.NET/Ytdlp.NET.csproj
+++ b/src/Ytdlp.NET/Ytdlp.NET.csproj
@@ -7,7 +7,7 @@
 		<PackageId>Ytdlp.NET</PackageId>
 		<AssemblyName>Ytdlp.NET</AssemblyName>
 		<RootNamespace>ManuHub.Ytdlp.NET</RootNamespace>
-		<Version>3.0.2</Version>
+		<Version>3.0.3</Version>
 		<Authors>ManuHub Manojbabu</Authors>
 		<PackageDescription>A .NET wrapper for yt-dlp with advanced features like concurrent downloads, SponsorBlock, and improved format parsing</PackageDescription>
 		<Copyright>© 2025-2026 ManuHub. Allrights researved</Copyright>
@@ -43,7 +43,8 @@
 			- Automatic resource cleanup with `await using`.
 			- Cross-platform (Windows, macOS, Linux).
 
-			⚠️ Breaking Changes
+			⚠️ Breaking Change
+			- Improve progress parsing and cancellation handling, which may require adjustments in event handling and cancellation token usage.
 			- All old command methods (SetFormat, SetOutputFolder, etc.) have been removed.
 			- Only the new fluent `WithXxx()` style remains.
 			- Namespace changed to `ManuHub.Ytdlp.NET`.

--- a/src/Ytdlp.NET/Ytdlp.cs
+++ b/src/Ytdlp.NET/Ytdlp.cs
@@ -934,18 +934,24 @@ public sealed class Ytdlp : IAsyncDisposable
     /// e.g. "aac>m4a/mov>mp4/mkv" will remux aac to m4a, mov to mp4 and anything else to mkv
     /// </summary>
     /// <param name="format">(currently supported: avi, flv, gif, mkv, mov, mp4, webm, aac, aiff, alac, flac, m4a, mka, mp3, ogg, opus, vorbis, wav).</param>
-    public Ytdlp WithRemuxVideo(MediaFormat format = MediaFormat.Mp4) => AddOption("--remux-video", format.ToString().ToLowerInvariant());
-
+    public Ytdlp WithRemuxVideo(string format)
+    {
+        if(string.IsNullOrWhiteSpace(format))
+            throw new ArgumentException("Remux format cannot be empty", nameof(format));
+        return this.AddOption("--remux-video", format.ToLowerInvariant());
+    }
 
     /// <summary>
-    /// Re-encode the video into another format if necessary. The syntax and supported formats are the same as WithRemuxVideo()
+    /// Re-encode the video into another format if necessary. The syntax and supported formats are the same as <see cref="WithRemuxVideo"/>
     /// </summary>
     /// <param name="format">(currently supported: avi, flv, gif, mkv, mov, mp4, webm, aac, aiff, alac, flac, m4a, mka, mp3, ogg, opus, vorbis, wav).</param>
     /// <param name="videoCodec"></param>
     /// <param name="audioCodec"></param>
-    public Ytdlp WithRecodeVideo(MediaFormat format = MediaFormat.Mp4, string? videoCodec = null, string? audioCodec = null)
+    public Ytdlp WithRecodeVideo(string format, string? videoCodec = null, string? audioCodec = null)
     {
-        var builder = AddOption("--recode-video", format.ToString().ToLowerInvariant());
+        if(string.IsNullOrWhiteSpace(format))
+            throw new ArgumentException("Recode format cannot be empty", nameof(format));
+        var builder = AddOption("--recode-video", format.ToLowerInvariant());
         if (!string.IsNullOrWhiteSpace(videoCodec))
             builder = builder.AddOption("--video-codec", videoCodec);
         if (!string.IsNullOrWhiteSpace(audioCodec))
@@ -1101,8 +1107,24 @@ public sealed class Ytdlp : IAsyncDisposable
     #endregion
 
     #region Core
+    /// <summary>
+    /// Returns a new instance of the Ytdlp class with the specified command-line flag added.
+    /// </summary>
+    /// <remarks>Use this method to add a single custom flag to the Ytdlp command invocation. This does not
+    /// modify the current instance, but returns a new one with the additional flag applied.</remarks>
+    /// <param name="flag">The command-line flag to add. Leading and trailing whitespace is ignored.</param>
+    /// <returns>A new Ytdlp instance that includes the specified flag in its configuration.</returns>
     public Ytdlp AddFlag(string flag) => new Ytdlp(this, extraFlags: new[] { flag.Trim() });
 
+    /// <summary>
+    /// Returns a new instance of the Ytdlp class with an additional command-line option specified by the given key and
+    /// value.
+    /// </summary>
+    /// <remarks>This method does not modify the current instance. Use this method to fluently add options
+    /// when constructing command-line arguments.</remarks>
+    /// <param name="key">The name of the command-line option to add. Leading and trailing whitespace is ignored. Cannot be null or empty.</param>
+    /// <param name="value">The value to assign to the specified command-line option. Cannot be null.</param>
+    /// <returns>A new Ytdlp instance that includes the specified option in addition to any existing options.</returns>
     public Ytdlp AddOption(string key, string value) => new Ytdlp(this, extraOptions: new[] { (key.Trim(), value) });
     #endregion
 
@@ -1163,6 +1185,13 @@ public sealed class Ytdlp : IAsyncDisposable
         return AddOption("--playlist-end", index.ToString());
     }
 
+    /// <summary>
+    /// Specifies a custom User-Agent string to be used for HTTP requests.
+    /// </summary>
+    /// <param name="userAgent">The User-Agent string to send with HTTP requests. Cannot be null, empty, or consist only of white-space
+    /// characters.</param>
+    /// <returns>A new instance of the Ytdlp class with the specified User-Agent option applied.</returns>
+    /// <exception cref="ArgumentException">Thrown if userAgent is null, empty, or consists only of white-space characters.</exception>
     public Ytdlp WithUserAgent(string userAgent)
     {
         if (string.IsNullOrWhiteSpace(userAgent))
@@ -1170,6 +1199,14 @@ public sealed class Ytdlp : IAsyncDisposable
         return AddOption("--user-agent", userAgent.Trim());
     }
 
+    /// <summary>
+    /// Sets the HTTP referer header to use for subsequent requests.
+    /// </summary>
+    /// <remarks>Use this method when the target resource requires a specific referer header for access or
+    /// authentication.</remarks>
+    /// <param name="referer">The referer URL to include in the HTTP header. Cannot be null, empty, or whitespace.</param>
+    /// <returns>A new instance of the <see cref="Ytdlp"/> class with the referer option applied.</returns>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="referer"/> is null, empty, or consists only of whitespace.</exception>
     public Ytdlp WithReferer(string referer)
     {
         if (string.IsNullOrWhiteSpace(referer))
@@ -1177,6 +1214,15 @@ public sealed class Ytdlp : IAsyncDisposable
         return AddOption("--referer", referer.Trim());
     }
 
+    /// <summary>
+    /// Adds a filter to include only videos whose titles match the specified regular expression.
+    /// </summary>
+    /// <remarks>Use this method to restrict downloads to videos with titles that match the given pattern.
+    /// This option corresponds to the '--match-title' command-line argument in yt-dlp.</remarks>
+    /// <param name="regex">A regular expression pattern used to match video titles. Cannot be null, empty, or consist only of white-space
+    /// characters.</param>
+    /// <returns>The current <see cref="Ytdlp"/> instance with the match title filter applied.</returns>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="regex"/> is null, empty, or consists only of white-space characters.</exception>
     public Ytdlp WithMatchTitle(string regex)
     {
         if (string.IsNullOrWhiteSpace(regex))
@@ -1184,6 +1230,13 @@ public sealed class Ytdlp : IAsyncDisposable
         return AddOption("--match-title", regex.Trim());
     }
 
+    /// <summary>
+    /// Adds an option to reject downloads with titles matching the specified regular expression.
+    /// </summary>
+    /// <param name="regex">A regular expression pattern used to filter out downloads by title. Titles matching this pattern will be
+    /// excluded.</param>
+    /// <returns>The current <see cref="Ytdlp"/> instance with the reject title option applied.</returns>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="regex"/> is null, empty, or consists only of white-space characters.</exception>
     public Ytdlp WithRejectTitle(string regex)
     {
         if (string.IsNullOrWhiteSpace(regex))
@@ -1191,6 +1244,12 @@ public sealed class Ytdlp : IAsyncDisposable
         return AddOption("--reject-title", regex.Trim());
     }
 
+    /// <summary>
+    /// Enables the break-on-reject option, causing the process to stop when a download is rejected.
+    /// </summary>
+    /// <remarks>Use this method to configure the process to halt immediately if any download is rejected,
+    /// rather than continuing with subsequent downloads.</remarks>
+    /// <returns>A new instance of the current object with the break-on-reject flag applied.</returns>
     public Ytdlp WithBreakOnReject() => AddFlag("--break-on-reject");
     #endregion
 
@@ -1205,14 +1264,14 @@ public sealed class Ytdlp : IAsyncDisposable
 
     public Ytdlp WithMp4PostProcessingPreset()
         => this
-            .WithRemuxVideo(MediaFormat.Mp4)
+            .WithRemuxVideo("mp4")
             .WithEmbedMetadata()
             .WithEmbedChapters()
             .WithEmbedThumbnail();
 
     public Ytdlp WithMkvOutput()
         => this
-            .WithRemuxVideo(MediaFormat.Mkv)
+            .WithRemuxVideo("mkv")
             .WithMergeOutputFormat("mkv");
 
     public Ytdlp WithMaxHeight(int height)
@@ -1872,7 +1931,7 @@ public sealed class Ytdlp : IAsyncDisposable
 
         // Special single-value options
         if (_cookiesFile is not null) { args.Add("--cookies"); args.Add(_cookiesFile); }
-        if (_cookiesFromBrowser is not null) { args.Add("--cookies-from-browser"); args.Add(Quote(_cookiesFromBrowser)); }
+        if (_cookiesFromBrowser is not null) { args.Add("--cookies-from-browser"); args.Add(_cookiesFromBrowser); }
         if (_proxy is not null) { args.Add("--proxy"); args.Add(_proxy); }
         if (_ffmpegLocation is not null) { args.Add("--ffmpeg-location"); args.Add(_ffmpegLocation); }
         if (_sponsorblockRemove is not null) { args.Add("--sponsorblock-remove"); args.Add(_sponsorblockRemove); }


### PR DESCRIPTION
- Change WithRemuxVideo/WithRecodeVideo to accept string formats for greater flexibility (e.g., "mp4>mkv")
- Add AddFlag and AddOption methods for custom yt-dlp arguments
- Expand README with full fluent API documentation and updated event docs
- Add helper methods: WithUserAgent, WithReferer, WithMatchTitle, WithRejectTitle, WithBreakOnReject
- Improve progress and post-processing event handling and parsing
- Expand post-processor regex, remove redundant SponsorBlock handler
- Bump version to 3.0.3 and update sample code for new API usage