### PR TITLE
Update to v3.1.0: Add specific version support to UpdateAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,13 @@ The library exposes **event‑driven progress reporting**, **metadata probing**,
 
 ---
 
-# 🚀 New in v3.0
+# 🚀 New in v3.1
 
 Major redesign for reliability and modern .NET usage.
 
 ### Highlights
 
+* Improved UpdateAsync with specific version support
 * Immutable **fluent builder API**
 * `IAsyncDisposable` implemented
 * Thread‑safe usage

--- a/src/Ytdlp.NET/README.md
+++ b/src/Ytdlp.NET/README.md
@@ -2,7 +2,7 @@
 
 # Ytdlp.NET
 
-> **v3.0**
+> **v3.1**
 
 **Ytdlp.NET** is a **fluent, strongly-typed .NET wrapper** around [`yt-dlp`](https://github.com/yt-dlp/yt-dlp). It provides a fully **async, event-driven interface** for downloading videos, extracting audio, retrieving metadata, and post-processing media from YouTube and hundreds of other platforms.
 
@@ -52,8 +52,9 @@ var ffmpegPath = Path.Combine(AppContext.BaseDirectory, "tools");
 
 ---
 
-## 🚀 New in v3.0
+## 🚀 New in v3.1
 
+* Improved UpdateAsync with specific version support.
 * Full support for `IAsyncDisposable` with `await using`.
 * Immutable builder (`WithXxx`) for safe instance reuse.
 * Updated examples for event-driven downloads.
@@ -65,7 +66,7 @@ var ffmpegPath = Path.Combine(AppContext.BaseDirectory, "tools");
 
 ## 🛠 Methods
 * `VersionAsync(CancellationToken ct)`
-* `UpdateAsync(UpdateChannel channel, CancellationToken ct)`
+* `UpdateAsync(UpdateChannel channel, string specificVersion, CancellationToken ct)`
 * `ExtractorsAsync(CancellationToken ct, int bufferKb)`
 * `GetMetadataAsync(string url, CancellationToken ct, int bufferKb)`
 * `GetMetadataRawAsync(string url, CancellationToken ct, int bufferKb)`

--- a/src/Ytdlp.NET/Ytdlp.NET.csproj
+++ b/src/Ytdlp.NET/Ytdlp.NET.csproj
@@ -7,9 +7,9 @@
 		<PackageId>Ytdlp.NET</PackageId>
 		<AssemblyName>Ytdlp.NET</AssemblyName>
 		<RootNamespace>ManuHub.Ytdlp.NET</RootNamespace>
-		<Version>3.0.4</Version>
+		<Version>3.1.0</Version>
 		<Authors>ManuHub Manojbabu</Authors>
-		<PackageDescription>A .NET wrapper for yt-dlp with advanced features like concurrent downloads, SponsorBlock, and improved format parsing</PackageDescription>
+		<PackageDescription>A .NET wrapper for yt-dlp, providing a fluent API and supporting thousands of websites with concurrent downloads, SponsorBlock, and improved format parsing</PackageDescription>
 		<Copyright>© 2025-2026 ManuHub. Allrights researved</Copyright>
 		<PackageTags>yt-dlp youtube downloader video audio subtitles thumbnails fluent-api progress-tracking csharp dotnet sponsorblock concurrent</PackageTags>
 		<PackageProjectUrl>https://github.com/manusoft/Ytdlp.NET</PackageProjectUrl>
@@ -20,7 +20,7 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<Icon>icon.png</Icon>
 		<PackageReleaseNotes>
-			Ytdlp.NET v3.0 ✨ Major Redesign with Fluent API
+			Ytdlp.NET v3.1 ✨ Minor update with improved update process and better documentation.
 
 			- Complete rewrite using an immutable, fluent API (`WithXxx()` methods).
 			- Added `IAsyncDisposable` support for proper async cleanup of processes.

--- a/src/Ytdlp.NET/Ytdlp.cs
+++ b/src/Ytdlp.NET/Ytdlp.cs
@@ -1380,27 +1380,31 @@ public sealed class Ytdlp : IAsyncDisposable
     /// Updates the underlying yt-dlp binary to the latest version on the specified release channel.
     /// </summary>
     /// <param name="channel">The release channel to pull updates from (Master, Nightly, Stable.).</param>
+    /// <param name="specificVersion">The specific version to update to. e.g., "2026.03.17" or "latest"</param>
     /// <param name="ct">A <see cref="CancellationToken"/> to abort the download and installation process.</param>
     /// <returns>
     /// A <see cref="string"/> containing the update log or the new version number; 
     /// returns an empty string or throws if the update process fails.
     /// </returns>
-    public async Task<string> UpdateAsync(UpdateChannel channel = UpdateChannel.Stable, CancellationToken ct = default)
+    public async Task<string> UpdateAsync(UpdateChannel channel = UpdateChannel.Stable, string? specificVersion = null, CancellationToken ct = default)
     {
-        var output = await Probe().RunAsync($"--update-to {channel.ToString().ToLowerInvariant()}", ct);
-        if (output is null)
+        string target = channel.ToString().ToLowerInvariant();
+
+        if(!string.IsNullOrWhiteSpace(specificVersion))
+            target += $"@{specificVersion.ToLowerInvariant()}";
+
+        var output = await Probe().RunAsync($"--update-to {target}", ct);
+        if (string.IsNullOrWhiteSpace(output))
             return string.Empty;
 
         // Analyze output for professional messages
         if (output.Contains("Updated", StringComparison.OrdinalIgnoreCase))
-            return "yt-dlp was successfully updated to the latest version.";
+            return $"yt-dlp was successfully updated to the latest {target}.";
 
         if (output.Contains("up to date", StringComparison.OrdinalIgnoreCase))
-            return "yt-dlp is already up to date.";
+            return $"yt-dlp is already up to date on {target}.";
 
-        return "yt-dlp update check completed (no changes detected).";
-
-
+        return output;
     }
 
     /// <summary>


### PR DESCRIPTION
Bump version to 3.1.0 and update README with new features. Enhance UpdateAsync to accept a specificVersion parameter, allowing updates to a chosen yt-dlp version. Improve method logic and documentation for clarity and usability.