### PR TITLE
Make Entity Duration property nullable

### DIFF
--- a/src/Ytdlp.NET/Models/Metadata.cs
+++ b/src/Ytdlp.NET/Models/Metadata.cs
@@ -331,7 +331,7 @@ public class Entry
     public string? Description { get; set; }
 
     [JsonPropertyName("duration")]
-    public float Duration { get; set; }
+    public float? Duration { get; set; }
 
     [JsonPropertyName("channel_id")]
     public string? ChannelId { get; set; } 


### PR DESCRIPTION
Changed Duration property to be nullable so that null durations can be properly parsed.