### PR TITLE
Support for non flat metadata downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,13 @@ The library exposes **event‑driven progress reporting**, **metadata probing**,
 
 ---
 
-# 🚀 New in v3.1
+# 🚀 New in v3.2
 
-Major redesign for reliability and modern .NET usage.
+* New `GetDeepMetadataAsync()` method for comprehensive metadata extraction.
+* New `GetDeepMetadataRawAsync()` for raw JSON metadata.
+* Improved `Metadata` model with more fields and better parsing.
+
+---
 
 ### Highlights
 
@@ -205,6 +209,26 @@ await ytdlp.DownloadBatchAsync(urls, maxConcurrency: 3);
 | `OnCommandCompleted`       | Process finished         |
 
 ---
+
+
+## 🛠 Methods
+* `VersionAsync(CancellationToken ct)`
+* `UpdateAsync(UpdateChannel channel, string specificVersion, CancellationToken ct)`
+* `ExtractorsAsync(CancellationToken ct, int bufferKb)`
+* `GetMetadataAsync(string url, CancellationToken ct, int bufferKb)`
+* `GetMetadataRawAsync(string url, CancellationToken ct, int bufferKb)`
+* `GetDeepMetadataAsync(string url, CancellationToken ct = default, bool tuneProcess = true, int bufferKb = 256)`
+* `GetDeepMetadataRawAsync(string url, CancellationToken ct = default, bool tuneProcess = true, int bufferKb = 256)`
+* `GetFormatsAsync(string url, CancellationToken ct, int bufferKb)`
+* `GetMetadataLiteAsync(string url, CancellationToken ct, int bufferKb)`
+* `GetMetadataLiteAsync(string url, IEnumerable<string> fields, CancellationToken ct, int bufferKb)`
+* `GetBestAudioFormatIdAsync(string url, CancellationToken ct, int bufferKb)`
+* `GetBestVideoFormatIdAsync(string url, int maxHeight, CancellationToken ct, int bufferKb)`
+* `ExecuteAsync(string url, CancellationToken ct)`
+* `ExecuteBatchAsync(IEnumerable<string> urls, int maxConcurrency, CancellationToken ct)`
+
+---
+
 
 # 🔧 Fluent API Methods
 

--- a/src/Ytdlp.NET.Console/Program.cs
+++ b/src/Ytdlp.NET.Console/Program.cs
@@ -12,7 +12,7 @@ internal class Program
         Console.InputEncoding = Encoding.UTF8;
 
         Console.Clear();
-        Console.WriteLine("Ytdlp.NET Wrapper v3.0 Demo Console App");
+        Console.WriteLine("Ytdlp.NET Wrapper v3.2 Demo Console App");
         Console.WriteLine("----------------------------------------");
 
         // Initialize the wrapper (assuming yt-dlp is in PATH or specify path)
@@ -20,15 +20,18 @@ internal class Program
             .WithFFmpegLocation("tools");
 
         // Run all demos/tests sequentially
-        //await TestGetVersionAsync(baseYtdlp);
-        //await TestUpdateAsync(baseYtdlp);
+        await TestGetVersionAsync(baseYtdlp);
+        await TestUpdateAsync(baseYtdlp);
 
         //await TestGetFormatsAsync(baseYtdlp);
-        //await TestGetMetadataAsync(baseYtdlp);
+        await TestGetMetadataAsync(baseYtdlp);
+        await TestGetMetedataRawAsync(baseYtdlp);
+        await TestGetDeepMetadataAsync(baseYtdlp);
+        await TestGetDeepMetadataRawAsync(baseYtdlp);
         //await TestGetLiteMetadataAsync(baseYtdlp);
         //await TestGetTitleAsync(baseYtdlp);
 
-        await TestDownloadVideoAsync(baseYtdlp);
+        //await TestDownloadVideoAsync(baseYtdlp);
         //await TestDownloadAudioAsync(baseYtdlp);
         //await TestBatchDownloadAsync(baseYtdlp);
         //await TestSponsorBlockAsync(baseYtdlp);
@@ -60,14 +63,14 @@ internal class Program
 
     private static async Task TestGetVersionAsync(Ytdlp ytdlp)
     {
-        Console.WriteLine("\nTest 1: Getting yt-dlp version...");
+        Console.WriteLine("\nTest 1:Getting yt-dlp version...");
         var version = await ytdlp.VersionAsync();
         Console.WriteLine($"Version: {version}");
     }
 
     private static async Task TestUpdateAsync(Ytdlp ytdlp)
     {
-        Console.WriteLine("\nTest 2: Checking yt-dlp update...");
+        Console.WriteLine("\nTest 2:Checking yt-dlp update...");
         var version = await ytdlp.UpdateAsync(UpdateChannel.Stable);
         Console.WriteLine($"Status: {version}");
     }
@@ -76,7 +79,7 @@ internal class Program
     {
         var stopwatch = Stopwatch.StartNew();
 
-        Console.WriteLine("\nTest 3: Fetching available formats...");
+        Console.WriteLine("\nTest 3:Fetching available formats...");
         var url = "https://www.youtube.com/watch?v=ZGnQH0LN_98";
         var formats = await ytdlp.GetFormatsAsync(url);
 
@@ -104,7 +107,7 @@ internal class Program
     {
         var stopwatch = Stopwatch.StartNew();
 
-        Console.WriteLine("\nTest 4: Fetching detailed metedata...");
+        Console.WriteLine("\nTest 4:Fetching detailed metedata...");
         var token = new CancellationTokenSource().Token; // In real use, you might want to cancel if it takes too long
         using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(90));
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token, timeoutCts.Token);
@@ -136,10 +139,63 @@ internal class Program
         }
     }
 
+    private static async Task TestGetMetedataRawAsync(Ytdlp ytdlp)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        Console.WriteLine("\nTest 5: Fetching raw metedata...");
+        var url = "https://www.youtube.com/watch?v=ZGnQH0LN_98";
+        var rawJson = await ytdlp.GetMetadataRawAsync(url);
+        stopwatch.Stop(); // stop timer
+        Console.WriteLine($"Raw metedata took {stopwatch.Elapsed.TotalSeconds:F3} seconds");
+        if (!string.IsNullOrEmpty(rawJson))
+        {
+            Console.WriteLine($"Raw JSON length: {rawJson.Length} characters");
+            // Optionally print the raw JSON (commented out for brevity)
+            // Console.WriteLine(rawJson);
+        }
+    }
+
+    private static async Task TestGetDeepMetadataAsync(Ytdlp ytdlp)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        Console.WriteLine("\nTest 6: Fetching deep metedata...");
+        var url = "https://www.youtube.com/watch?v=ZGnQH0LN_98";
+        var metadata = await ytdlp.GetDeepMetadataAsync(url);
+        stopwatch.Stop(); // stop timer
+        Console.WriteLine($"Deep metedata took {stopwatch.Elapsed.TotalSeconds:F3} seconds");
+        if (metadata != null)
+        {
+            Console.WriteLine($"Type: {metadata.Type}");
+            Console.WriteLine($"ID: {metadata.Id}");
+            Console.WriteLine($"Title: {metadata.Title}");
+            Console.WriteLine($"Uploader: {metadata.Uploader}");
+            Console.WriteLine($"Upload Date: {metadata.UploadDate}");
+            Console.WriteLine($"View Count: {metadata.ViewCount}");
+            Console.WriteLine($"Like Count: {metadata.LikeCount}");
+            // And more fields as needed...
+        }
+    }
+
+    private static async Task TestGetDeepMetadataRawAsync(Ytdlp ytdlp)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        Console.WriteLine("\nTest 7: Fetching deep raw metedata...");
+        var url = "https://www.youtube.com/watch?v=ZGnQH0LN_98";
+        var rawJson = await ytdlp.GetDeepMetadataRawAsync(url);
+        stopwatch.Stop(); // stop timer
+        Console.WriteLine($"Deep raw metedata took {stopwatch.Elapsed.TotalSeconds:F3} seconds");
+        if (!string.IsNullOrEmpty(rawJson))
+        {
+            Console.WriteLine($"Deep Raw JSON length: {rawJson.Length} characters");
+            // Optionally print the raw JSON (commented out for brevity)
+            // Console.WriteLine(rawJson);
+        }
+    }
+
     private static async Task TestGetLiteMetadataAsync(Ytdlp ytdlp)
     {
         var stopwatch = Stopwatch.StartNew();
-        Console.WriteLine("\nTest 5: Fetching lite metedata...");
+        Console.WriteLine("\nTest 8: Fetching lite metedata...");
 
         var url = "https://www.youtube.com/watch?v=ZGnQH0LN_98";
 
@@ -159,7 +215,7 @@ internal class Program
     // Test 6: Download a video with progress events
     private static async Task TestDownloadVideoAsync(Ytdlp ytdlpBase)
     {
-        Console.WriteLine("\nTest 6: Downloading a video...");
+        Console.WriteLine("\nTest 9: Downloading a video...");
         var url = "https://www.youtube.com/watch?v=2vTkipUlhik"; //"https://www.dailymotion.com/video/xa3ron2"; 
 
         var ytdlp = ytdlpBase
@@ -207,7 +263,7 @@ internal class Program
 
     private static async Task TestDownloadAudioAsync(Ytdlp ytdlpBase)
     {
-        Console.WriteLine("\nTest 7: Extracting audio...");
+        Console.WriteLine("\nTest 10: Extracting audio...");
         var url = "https://www.youtube.com/watch?v=ZGnQH0LN_98";
 
         var ytdlp = ytdlpBase
@@ -221,7 +277,7 @@ internal class Program
     // Test 8: Batch download (concurrent)
     private static async Task TestBatchDownloadAsync(Ytdlp baseYtdlp)
     {
-        Console.WriteLine("\nTest 8: Batch download (3 concurrent)...");
+        Console.WriteLine("\nTest 11: Batch download (3 concurrent)...");
         var urls = new List<string>
             {
                 "https://www.youtube.com/watch?v=ZGnQH0LN_98",
@@ -239,7 +295,7 @@ internal class Program
     // Test 9: SponsorBlock removal
     private static async Task TestSponsorBlockAsync(Ytdlp ytdlpBase)
     {
-        Console.WriteLine("\nTest 9: Download with SponsorBlock removal...");
+        Console.WriteLine("\nTest 12: Download with SponsorBlock removal...");
         var url = "https://www.youtube.com/watch?v=oDSEGkT6J-0";
 
         var ytdlp = ytdlpBase
@@ -253,7 +309,7 @@ internal class Program
     // Test 10: Concurrent fragments (faster download)
     private static async Task TestConcurrentFragmentsAsync(Ytdlp ytdlpBase)
     {
-        Console.WriteLine("\nTest 10: Download with concurrent fragments...");
+        Console.WriteLine("\nTest 13: Download with concurrent fragments...");
         var url = "https://www.youtube.com/watch?v=oDSEGkT6J-0";
 
         var ytdlp = ytdlpBase
@@ -271,7 +327,7 @@ internal class Program
     // Test 11: Cancellation support
     private static async Task TestCancellationAsync(Ytdlp ytdlp)
     {
-        Console.WriteLine("\nTest 11: Testing cancellation (will cancel after 10 seconds)...");
+        Console.WriteLine("\nTest 14: Testing cancellation (will cancel after 10 seconds)...");
         var url = "https://www.youtube.com/watch?v=zGlwuHqGVIA";  // A longer video
 
         var cts = new CancellationTokenSource();
@@ -309,7 +365,7 @@ internal class Program
     // Test 12: Get Title Test
     private static async Task TestGetTitleAsync(Ytdlp ytdlp)
     {
-        Console.WriteLine("\nTest 12: Get Title Test");
+        Console.WriteLine("\nTest 15: Get Title Test");
         var url = "https://www.youtube.com/watch?v=zGlwuHqGVIA";
 
         try

--- a/src/Ytdlp.NET/Models/Metadata.cs
+++ b/src/Ytdlp.NET/Models/Metadata.cs
@@ -316,7 +316,7 @@ public class FragmentMetadata
 public class Entry
 {
     [JsonPropertyName("type")]
-    public string? Type { get; set; }
+    public string? Type { get; set; } // "playlist", "season", "video"
 
     [JsonPropertyName("id")]
     public string? Id { get; set; }
@@ -354,10 +354,10 @@ public class Entry
     [JsonPropertyName("thumbnails")]
     public List<ThumbnailMetadata>? Thumbnails { get; set; }
 
-    /// <summary>
-    /// How many users have watched the video on the platform
-    /// </summary>
     [JsonPropertyName("view_count")]
     public float? ViewCount { get; set; }
+
+    [JsonPropertyName("entries")]
+    public List<Entry>? Entries { get; set; }   // deep playlist / season / episode support
 
 }

--- a/src/Ytdlp.NET/README.md
+++ b/src/Ytdlp.NET/README.md
@@ -2,7 +2,7 @@
 
 # Ytdlp.NET
 
-> **v3.1**
+> **v3.2**
 
 **Ytdlp.NET** is a **fluent, strongly-typed .NET wrapper** around [`yt-dlp`](https://github.com/yt-dlp/yt-dlp). It provides a fully **async, event-driven interface** for downloading videos, extracting audio, retrieving metadata, and post-processing media from YouTube and hundreds of other platforms.
 
@@ -52,8 +52,11 @@ var ffmpegPath = Path.Combine(AppContext.BaseDirectory, "tools");
 
 ---
 
-## 🚀 New in v3.1
+## 🚀 New in v3.2
 
+* New `GetDeepMetadataAsync()` method for comprehensive metadata extraction.
+* New `GetDeepMetadataRawAsync()` for raw JSON metadata.
+* Improved `Metadata` model with more fields and better parsing.
 * Improved UpdateAsync with specific version support.
 * Full support for `IAsyncDisposable` with `await using`.
 * Immutable builder (`WithXxx`) for safe instance reuse.
@@ -70,6 +73,8 @@ var ffmpegPath = Path.Combine(AppContext.BaseDirectory, "tools");
 * `ExtractorsAsync(CancellationToken ct, int bufferKb)`
 * `GetMetadataAsync(string url, CancellationToken ct, int bufferKb)`
 * `GetMetadataRawAsync(string url, CancellationToken ct, int bufferKb)`
+* `GetDeepMetadataAsync(string url, CancellationToken ct = default, bool tuneProcess = true, int bufferKb = 256)`
+* `GetDeepMetadataRawAsync(string url, CancellationToken ct = default, bool tuneProcess = true, int bufferKb = 256)`
 * `GetFormatsAsync(string url, CancellationToken ct, int bufferKb)`
 * `GetMetadataLiteAsync(string url, CancellationToken ct, int bufferKb)`
 * `GetMetadataLiteAsync(string url, IEnumerable<string> fields, CancellationToken ct, int bufferKb)`
@@ -77,7 +82,6 @@ var ffmpegPath = Path.Combine(AppContext.BaseDirectory, "tools");
 * `GetBestVideoFormatIdAsync(string url, int maxHeight, CancellationToken ct, int bufferKb)`
 * `ExecuteAsync(string url, CancellationToken ct)`
 * `ExecuteBatchAsync(IEnumerable<string> urls, int maxConcurrency, CancellationToken ct)`
-
 
 
 ## 🔧 Thread Safety & Disposal

--- a/src/Ytdlp.NET/Ytdlp.cs
+++ b/src/Ytdlp.NET/Ytdlp.cs
@@ -1390,7 +1390,7 @@ public sealed class Ytdlp : IAsyncDisposable
     {
         string target = channel.ToString().ToLowerInvariant();
 
-        if(!string.IsNullOrWhiteSpace(specificVersion))
+        if (!string.IsNullOrWhiteSpace(specificVersion))
             target += $"@{specificVersion.ToLowerInvariant()}";
 
         var output = await Probe().RunAsync($"--update-to {target}", ct);
@@ -1460,32 +1460,15 @@ public sealed class Ytdlp : IAsyncDisposable
     /// <exception cref="ArgumentException"></exception>
     public async Task<Metadata?> GetMetadataAsync(string url, CancellationToken ct = default, bool tuneProcess = true, int bufferKb = 256)
     {
-        if (string.IsNullOrWhiteSpace(url))
-            throw new ArgumentException("URL cannot be empty.", nameof(url));
+        var json = await GetMetadataInternalAsync(url, flat: true, ct, tuneProcess, bufferKb);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            _logger.Log(LogType.Warning, "Empty JSON output.");
+            return null;
+        }
 
         try
         {
-            var arguments =
-                $"--dump-single-json " +
-                $"--simulate " +
-                $"--skip-download " +
-                $"--flat-playlist " +
-                $"--lazy-playlist " +
-                $"--quiet " +
-                $"--no-warnings " +
-                $"{Quote(url)}";
-
-            if (ct.IsCancellationRequested)
-                Debug.WriteLine("Cancellation requested before starting the process.");
-
-            var json = await Probe().RunAsync(arguments, ct, tuneProcess, bufferKb);
-
-            if (string.IsNullOrWhiteSpace(json))
-            {
-                _logger.Log(LogType.Warning, "Empty JSON output.");
-                return null;
-            }
-
             var options = new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true,
@@ -1493,16 +1476,11 @@ public sealed class Ytdlp : IAsyncDisposable
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
             };
 
-            return JsonSerializer.Deserialize<Metadata>(json, options);
+            var metadata = JsonSerializer.Deserialize<Metadata>(json, options);
+            return metadata;
         }
-        catch (OperationCanceledException)
+        catch (Exception)
         {
-            _logger.Log(LogType.Warning, "Metadata fetch cancelled.");
-            return null;
-        }
-        catch (Exception ex)
-        {
-            _logger.Log(LogType.Warning, $"Metadata fetch failed: {ex.Message}");
             return null;
         }
     }
@@ -1513,13 +1491,85 @@ public sealed class Ytdlp : IAsyncDisposable
     /// <param name="url">The source URL (video or playlist) to probe.</param>
     /// <param name="ct">The <see cref="CancellationToken"/> to abort the process.</param>
     /// <param name="tuneProcess">Whether to tune the process for better performance (true by default). If false, the process will use the default buffer size and may have slower output processing.</param>
-    /// <param name="bufferKb">The buffer size for the process output stream (default 128KB).</param>
+    /// <param name="bufferKb">The buffer size for the process output stream (default 256KB).</param>
     /// <returns>
-    /// A raw JSON <see cref="object"/> containing the parsed metadata output; 
+    /// A raw JSON <see cref="string"/> containing the parsed metadata output; 
     /// returns <see langword="null"/> if the process fails, returns empty, or is cancelled.
     /// </returns>
     /// <exception cref="ArgumentException"></exception>
-    public async Task<object?> GetMetadataRawAsync(string url, CancellationToken ct = default, bool tuneProcess = true, int bufferKb = 256)
+    public async Task<string?> GetMetadataRawAsync(string url, CancellationToken ct = default, bool tuneProcess = true, int bufferKb = 256)
+    {
+       var json = await GetMetadataInternalAsync(url, flat: true, ct, tuneProcess, bufferKb);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            _logger.Log(LogType.Warning, "Empty JSON output.");
+            return null;
+        }
+        return json;
+    }
+
+
+    /// <summary>
+    /// Gets deep metadata for the specified URL by requesting non-flat JSON and deserializing it into a Metadata object.
+    /// </summary>
+    /// <remarks>Requests non-flat JSON via GetMetadataInternalAsync. Logs a warning when the JSON output is
+    /// empty. Deserialization uses case-insensitive property names and allows numeric values provided as strings; any
+    /// deserialization error results in a null return.</remarks>
+    /// <param name="url">The resource URL to retrieve metadata from.</param>
+    /// <param name="ct">Cancellation token to cancel the operation.</param>
+    /// <param name="tuneProcess">True to enable process tuning for metadata retrieval; otherwise false.</param>
+    /// <param name="bufferKb">Read buffer size in kilobytes used when retrieving metadata.</param>
+    /// <returns>A Metadata instance if JSON is present and deserialization succeeds; otherwise null.</returns>
+    public async Task<Metadata?> GetDeepMetadataAsync(string url, CancellationToken ct = default, bool tuneProcess = true, int bufferKb = 256)
+    {
+        var json = await GetMetadataInternalAsync(url, flat: false, ct, tuneProcess, bufferKb);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            _logger.Log(LogType.Warning, "Empty JSON output.");
+            return null;
+        }
+
+        try
+        {
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+                NumberHandling = JsonNumberHandling.AllowReadingFromString,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            };
+
+            var metadata = JsonSerializer.Deserialize<Metadata>(json, options);
+            return metadata;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously retrieves deep (non-flattened) metadata for the specified URL as raw JSON.
+    /// </summary>
+    /// <remarks>Invokes GetMetadataInternalAsync with flat set to false. Logs a warning when the returned
+    /// JSON is null or consists only of whitespace.</remarks>
+    /// <param name="url">The URL from which to retrieve metadata.</param>
+    /// <param name="ct">A cancellation token to cancel the asynchronous operation.</param>
+    /// <param name="tuneProcess">Whether to apply process tuning for the metadata retrieval.</param>
+    /// <param name="bufferKb">Read buffer size in kilobytes used during metadata retrieval.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result is a JSON string containing deep
+    /// (non-flattened) metadata, or null if the output is empty.</returns>
+    public async Task<string?> GetDeepMetadataRawAsync(string url, CancellationToken ct = default, bool tuneProcess = true, int bufferKb = 256)
+    {
+        var json = await GetMetadataInternalAsync(url, flat: false, ct, tuneProcess, bufferKb);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            _logger.Log(LogType.Warning, "Empty JSON output.");
+            return null;
+        }
+        return json;
+    }
+
+    private async Task<string?> GetMetadataInternalAsync(string url, bool flat, CancellationToken ct, bool tuneProcess, int bufferKb)
     {
         if (string.IsNullOrWhiteSpace(url))
             throw new ArgumentException("URL cannot be empty.", nameof(url));
@@ -1527,22 +1577,19 @@ public sealed class Ytdlp : IAsyncDisposable
         try
         {
             var arguments =
-                $"--dump-single-json " +
-                $"--simulate " +
-                $"--skip-download " +
-                $"--flat-playlist " +
-                $"--lazy-playlist " +
-                $"--quiet " +
-                $"--no-warnings " +
+                "--dump-single-json " +
+                "--simulate " +
+                "--skip-download " +
+                (flat ? "--flat-playlist " : "") +   // ✅ KEY SWITCH
+                "--lazy-playlist " +
+                "--quiet " +
+                "--no-warnings " +
                 $"{Quote(url)}";
 
-            var json = await Probe().RunAsync(arguments, ct, tuneProcess, bufferKb);
+            if (ct.IsCancellationRequested)
+                Debug.WriteLine("Cancellation requested before starting process.");
 
-            if (string.IsNullOrWhiteSpace(json))
-            {
-                _logger.Log(LogType.Warning, "Empty JSON output.");
-                return null;
-            }
+            var json = await Probe().RunAsync(arguments, ct, tuneProcess, bufferKb);                  
 
             return json;
         }
@@ -1822,7 +1869,7 @@ public sealed class Ytdlp : IAsyncDisposable
 
         // Forward other events        
         void OnPostProcessingStartHandler(object? s, string msg) => OnPostProcessingStart?.Invoke(this, msg);
-        void OnPostProcessingCompleteHandler(object? s, string msg) => OnPostProcessingComplete?.Invoke(this, msg);       
+        void OnPostProcessingCompleteHandler(object? s, string msg) => OnPostProcessingComplete?.Invoke(this, msg);
         progressParser.OnPostProcessingStart += OnPostProcessingStartHandler;
         progressParser.OnPostProcessingComplete += OnPostProcessingCompleteHandler;
 
@@ -1843,7 +1890,7 @@ public sealed class Ytdlp : IAsyncDisposable
             // Unsubscribe immediately after execution to prevent memory leaks
             progressParser.OnProgressDownload -= OnProgressDownloadHandler;
             progressParser.OnProgressMessage -= OnProgressMessageHandler;
-            progressParser.OnCompleteDownload -= OnCompleteDownloadHanlder;            
+            progressParser.OnCompleteDownload -= OnCompleteDownloadHanlder;
             progressParser.OnPostProcessingStart -= OnPostProcessingStartHandler;
             progressParser.OnPostProcessingComplete -= OnPostProcessingCompleteHandler;
             download.OnOutput -= OnOutputMessageHandler;


### PR DESCRIPTION
Add deep metadata extraction methods and update docs

Refactored metadata retrieval in Ytdlp.cs to support new GetDeepMetadataAsync and GetDeepMetadataRawAsync methods for comprehensive and raw JSON extraction. Updated GetMetadataAsync to use a shared internal method, changed GetMetadataRawAsync to return a string, and improved error handling. Updated README for v3.2 features and improved documentation. Minor code cleanup and event handler formatting.

#32 