### PR TITLE
Fixed download progress bug in ProgressParser

### DIFF
--- a/src/Ytdlp.NET/Extensions/EntryExtensions.cs
+++ b/src/Ytdlp.NET/Extensions/EntryExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace ManuHub.Ytdlp.NET.Extensions;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace ManuHub.Ytdlp.NET.Extensions;
 
 public static class EntryExtensions
 {
@@ -6,7 +8,7 @@ public static class EntryExtensions
     {
         yield return entry;
 
-        if (entry.Entries == null || entry.Entries.Count == 0)
+        if (!entry.Entries.HasChildren())
             yield break;
 
         foreach (var child in entry.Entries)
@@ -17,4 +19,7 @@ public static class EntryExtensions
             }
         }
     }
+
+    public static bool HasChildren([NotNullWhen(true)]this List<Entry>? entries)
+        => entries != null && entries.Count > 0;
 }

--- a/src/Ytdlp.NET/Extensions/MetadataExtensions.cs
+++ b/src/Ytdlp.NET/Extensions/MetadataExtensions.cs
@@ -1,0 +1,24 @@
+﻿namespace ManuHub.Ytdlp.NET.Extensions;
+
+public static class MetadataExtensions
+{
+    public static Metadata Flatten(this Metadata metadata)
+    {
+        if (metadata.Entries?.All(e => !e.Entries.HasChildren()) ?? true)
+            return metadata; // No nested playlists, return as is
+
+        // Select end nodes with Title and (null-coalesced) Url
+        var flattenedEntries = metadata.Entries
+            .SelectMany(e => e.Traverse())
+            .Where(e => !e.Entries.HasChildren() && !string.IsNullOrWhiteSpace(e.Title))
+            .Select(e => e with { Url = e.Url ?? e.OriginalUrl ?? e.WebpageUrl })
+            .Where(e => !string.IsNullOrWhiteSpace(e.Url))
+            .ToList();
+
+        return metadata with
+        {
+            Type = "playlist",
+            Entries = flattenedEntries
+        };
+    }
+}

--- a/src/Ytdlp.NET/Models/Metadata.cs
+++ b/src/Ytdlp.NET/Models/Metadata.cs
@@ -2,7 +2,7 @@
 
 namespace ManuHub.Ytdlp.NET;
 
-public class Metadata
+public record class Metadata
 {
     /// <summary>
     /// Video identifier
@@ -313,7 +313,7 @@ public class FragmentMetadata
     public double Duration { get; set; }
 }
 
-public class Entry
+public record class Entry
 {
     [JsonPropertyName("type")]
     public string? Type { get; set; } // "playlist", "season", "video"
@@ -356,6 +356,12 @@ public class Entry
 
     [JsonPropertyName("view_count")]
     public float? ViewCount { get; set; }
+
+    [JsonPropertyName("webpage_url")]
+    public string? WebpageUrl { get; set; }  // playlist/video
+
+    [JsonPropertyName("original_url")]
+    public string? OriginalUrl { get; set; }  // playlist/video
 
     [JsonPropertyName("entries")]
     public List<Entry>? Entries { get; set; }   // deep playlist / season / episode support

--- a/src/Ytdlp.NET/Parsing/ProgressParser.cs
+++ b/src/Ytdlp.NET/Parsing/ProgressParser.cs
@@ -106,15 +106,15 @@ public sealed class ProgressParser
 
     private void HandleDownloadProgress(Match match)
     {
-        if (_isDownloadCompleted) return;
-
         string percentString = match.Groups["percent"].Value;
         string sizeString = match.Groups["total"].Value;
         string speedString = match.Groups["speed"].Value;
         string etaString = match.Groups["eta"].Value;
 
-        if (!double.TryParse(percentString.Replace("%", ""), out double percent))
-            percent = 0;
+        var isParsed = double.TryParse(percentString.Replace("%", ""), out double percent);
+
+        if (!isParsed) percent = 0;
+        if (!isParsed || percent >= 100) return;
 
         var args = new DownloadProgressEventArgs
         {
@@ -136,16 +136,16 @@ public sealed class ProgressParser
 
     private void HandleDownloadProgressWithFrag(Match match)
     {
-        if (_isDownloadCompleted) return;
-
         string percentString = match.Groups["percent"].Value;
         string sizeString = match.Groups["size"].Value;
         string speedString = match.Groups["speed"].Value;
         string etaString = match.Groups["eta"].Value;
         string fragString = match.Groups["frag"].Value;
 
-        if (!double.TryParse(percentString.Replace("%", ""), out double percent))
-            percent = 0;
+        var isParsed = double.TryParse(percentString.Replace("%", ""), out double percent);
+
+        if (!isParsed) percent = 0;
+        if (!isParsed || percent >= 100) return;
 
         var args = new DownloadProgressEventArgs
         {
@@ -167,9 +167,9 @@ public sealed class ProgressParser
         }
     }
 
-    private bool IsFinalFragment(string frag)
+    private static bool IsFinalFragment(string frag)
     {
-        if (string.IsNullOrEmpty(frag) || !frag.Contains("/")) return true;
+        if (string.IsNullOrEmpty(frag) || !frag.Contains('/')) return true;
 
         var parts = frag.Split('/');
         if (parts.Length != 2) return false;


### PR DESCRIPTION
Fixed bug in ProgressParser where download would be marked as complete when yt-dlp completes the first download (web page), and then doesn't send progress updates for subsequent downloads (video / audio / subtitles / etc).

Fixes #36 