### PR TITLE
Added Metadata.Flatten() method

### DIFF
--- a/src/Ytdlp.NET/Extensions/EntryExtensions.cs
+++ b/src/Ytdlp.NET/Extensions/EntryExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace ManuHub.Ytdlp.NET.Extensions;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace ManuHub.Ytdlp.NET.Extensions;
 
 public static class EntryExtensions
 {
@@ -6,7 +8,7 @@ public static class EntryExtensions
     {
         yield return entry;
 
-        if (entry.Entries == null || entry.Entries.Count == 0)
+        if (!entry.Entries.HasChildren())
             yield break;
 
         foreach (var child in entry.Entries)
@@ -17,4 +19,7 @@ public static class EntryExtensions
             }
         }
     }
+
+    public static bool HasChildren([NotNullWhen(true)]this List<Entry>? entries)
+        => entries != null && entries.Count > 0;
 }

--- a/src/Ytdlp.NET/Extensions/MetadataExtensions.cs
+++ b/src/Ytdlp.NET/Extensions/MetadataExtensions.cs
@@ -1,0 +1,24 @@
+﻿namespace ManuHub.Ytdlp.NET.Extensions;
+
+public static class MetadataExtensions
+{
+    public static Metadata Flatten(this Metadata metadata)
+    {
+        if (metadata.Entries?.All(e => !e.Entries.HasChildren()) ?? true)
+            return metadata; // No nested playlists, return as is
+
+        // Select end nodes with Title and (null-coalesced) Url
+        var flattenedEntries = metadata.Entries
+            .SelectMany(e => e.Traverse())
+            .Where(e => !e.Entries.HasChildren() && !string.IsNullOrWhiteSpace(e.Title))
+            .Select(e => e with { Url = e.Url ?? e.OriginalUrl ?? e.WebpageUrl })
+            .Where(e => !string.IsNullOrWhiteSpace(e.Url))
+            .ToList();
+
+        return metadata with
+        {
+            Type = "playlist",
+            Entries = flattenedEntries
+        };
+    }
+}

--- a/src/Ytdlp.NET/Models/Metadata.cs
+++ b/src/Ytdlp.NET/Models/Metadata.cs
@@ -2,7 +2,7 @@
 
 namespace ManuHub.Ytdlp.NET;
 
-public class Metadata
+public record class Metadata
 {
     /// <summary>
     /// Video identifier
@@ -313,7 +313,7 @@ public class FragmentMetadata
     public double Duration { get; set; }
 }
 
-public class Entry
+public record class Entry
 {
     [JsonPropertyName("type")]
     public string? Type { get; set; } // "playlist", "season", "video"
@@ -356,6 +356,12 @@ public class Entry
 
     [JsonPropertyName("view_count")]
     public float? ViewCount { get; set; }
+
+    [JsonPropertyName("webpage_url")]
+    public string? WebpageUrl { get; set; }  // playlist/video
+
+    [JsonPropertyName("original_url")]
+    public string? OriginalUrl { get; set; }  // playlist/video
 
     [JsonPropertyName("entries")]
     public List<Entry>? Entries { get; set; }   // deep playlist / season / episode support


### PR DESCRIPTION
Adding the ability to flatten deep Metadata so it can be processed the same way as flat Metadata.

Maybe controversial:  By changing the Metadata and Entry classes into `record classes` (C# 10), the `with` keyword can be used to easily create a new instance with modified properties.