### PR TITLE
Refactor tests, add CI for integration with yt-dlp

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,42 @@
+name: Weekly Integration Tests
+
+on:
+  push:
+    branches: [ master ]
+#on:
+#  schedule:
+#    # Runs automatically every Sunday at midnight UTC
+#    - cron: '0 0 * * 0'
+#  workflow_dispatch: 
+    # Adds a manual "Run workflow" button in the GitHub Actions UI for easy debugging
+
+jobs:
+  integration:
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
+    # ── THIS IS WHAT INSTALLS YT-DLP ──────────────────────────────────
+    - name: Set up yt-dlp
+      uses: yt-dlp/setup-ytdlp@v1
+      with:
+        # Optional: Defaults to 'latest', ensures you test against what your users are using
+        version: 'latest' 
+
+    # ── Verify the installation works in the logs ────────────────────
+    - name: Check yt-dlp Version
+      run: yt-dlp --version
+
+    # ── Run the integration test suite ────────────────────────────────
+    - name: Run Integration Tests
+      env:
+        # Crucial! This flips your [SkippableFact] flags from Skipped to Active
+        YTDLP_INTEGRATION_TESTS: "1" 
+      run: dotnet test tests/Ytdlp.NET.Test/Ytdlp.NET.Test.csproj -c Release

--- a/tests/Ytdlp.NET.Test/AudioFormatTests.cs
+++ b/tests/Ytdlp.NET.Test/AudioFormatTests.cs
@@ -7,7 +7,7 @@ namespace ManuHub.Ytdlp.NET.Test;
 /// Verifies that all documented formats are present so a rename or removal
 /// is caught immediately.
 /// </summary>
-public class AudioFormatTests : IDisposable
+public class AudioFormatTests 
 {
     private readonly string _fullFakePath;
 
@@ -33,12 +33,6 @@ public class AudioFormatTests : IDisposable
                 // ignore the error because the file is being taken care of.
             }
         }
-    }
-
-    public void Dispose()
-    {
-        // Clean up the dummy file after all tests in this class finish
-        //try { File.Delete(_fullFakePath); } catch { }
     }
 
     [Theory]

--- a/tests/Ytdlp.NET.Test/YtdlpBuilderTests.cs
+++ b/tests/Ytdlp.NET.Test/YtdlpBuilderTests.cs
@@ -9,7 +9,7 @@ namespace ManuHub.YtdlpNET.Test;
 /// that the resulting argument list contains the expected flags/values.
 /// No yt-dlp process is ever launched here.
 /// </summary>
-public class YtdlpBuilderTests : IDisposable
+public class YtdlpBuilderTests 
 {
     private readonly string _fullFakePath;
 
@@ -35,12 +35,6 @@ public class YtdlpBuilderTests : IDisposable
                 // ignore the error because the file is being taken care of.
             }
         }
-    }
-
-    public void Dispose()
-    {
-        // Clean up the dummy file after all tests in this class finish
-        //try { File.Delete(_fullFakePath); } catch { }
     }
 
     // ── Construction ──────────────────────────────────────────────────────

--- a/tests/Ytdlp.NET.Test/YtdlpCancellationTests.cs
+++ b/tests/Ytdlp.NET.Test/YtdlpCancellationTests.cs
@@ -8,7 +8,7 @@ namespace ManuHub.Ytdlp.NET.Test;
 /// These tests do NOT require yt-dlp.exe to be installed — the cancellation
 /// should be observed before any process is started (or very quickly after).
 /// </summary>
-public class YtdlpCancellationTests : IDisposable
+public class YtdlpCancellationTests 
 {
     private readonly string _fullFakePath;
 
@@ -34,12 +34,6 @@ public class YtdlpCancellationTests : IDisposable
                 // ignore the error because the file is being taken care of.
             }
         }
-    }
-
-    public void Dispose()
-    {
-        // Clean up the dummy file after all tests in this class finish
-        //try { File.Delete(_fullFakePath); } catch { }
     }
 
     [Fact]

--- a/tests/Ytdlp.NET.Test/YtdlpEventTests.cs
+++ b/tests/Ytdlp.NET.Test/YtdlpEventTests.cs
@@ -7,7 +7,7 @@ namespace ManuHub.Ytdlp.NET.Test;
 /// error, and that subscriptions on a shared base instance don't bleed into
 /// branched instances.
 /// </summary>
-public class YtdlpEventTests : IDisposable
+public class YtdlpEventTests 
 {
 
     private readonly string _fullFakePath;
@@ -36,11 +36,6 @@ public class YtdlpEventTests : IDisposable
         }
     }
 
-    public void Dispose()
-    {
-        // Clean up the dummy file after all tests in this class finish
-        //try { File.Delete(_fullFakePath); } catch { }
-    }
 
     [Fact]
     public void OnProgressDownload_CanSubscribe()

--- a/tests/Ytdlp.NET.Test/YtdlpIntegrationTests.cs
+++ b/tests/Ytdlp.NET.Test/YtdlpIntegrationTests.cs
@@ -9,37 +9,13 @@ namespace ManuHub.Ytdlp.NET.Test;
 /// set the YTDLP_INTEGRATION_TESTS environment variable to "1" to enable them.
 /// </summary>
 [Collection("Integration")]
-public class YtdlpIntegrationTests : IDisposable
+public class YtdlpIntegrationTests 
 {
     private static readonly bool RunIntegration =
         Environment.GetEnvironmentVariable("YTDLP_INTEGRATION_TESTS") == "1";
 
     // A short, stable, public-domain video suitable for testing
     private const string TestVideoUrl = "https://www.youtube.com/watch?v=BaW_jenozKc";
-
-
-    private readonly string _fullFakePath;
-
-    public YtdlpIntegrationTests()
-    {
-        // 1. Get the directory and combine cross-platform paths
-        string toolsDir = Path.Combine(AppContext.BaseDirectory, "tools");
-        string exeName = OperatingSystem.IsWindows() ? "yt-dlp.exe" : "yt-dlp";
-        _fullFakePath = Path.Combine(toolsDir, exeName);
-        // 2. Ensure the directory and a dummy file exist so ValidatePath passes
-        Directory.CreateDirectory(toolsDir);
-        if (!File.Exists(_fullFakePath))
-        {
-            File.WriteAllText(_fullFakePath, "");
-        }
-    }
-
-    public void Dispose()
-    {
-        // Clean up the dummy file after all tests in this class finish
-        //try { File.Delete(_fullFakePath); } catch { }
-    }
-
 
     
     // ── VersionAsync ──────────────────────────────────────────────────────
@@ -49,7 +25,7 @@ public class YtdlpIntegrationTests : IDisposable
     {
         Skip.IfNot(RunIntegration, "Set YTDLP_INTEGRATION_TESTS=1 to run integration tests.");
 
-        await using var ytdlp = new Ytdlp(_fullFakePath);
+        await using var ytdlp = new Ytdlp("yt-dlp");
 
         var version = await ytdlp.VersionAsync();
 
@@ -64,7 +40,7 @@ public class YtdlpIntegrationTests : IDisposable
     {
         Skip.IfNot(RunIntegration, "Set YTDLP_INTEGRATION_TESTS=1 to run integration tests.");
 
-        await using var ytdlp = new Ytdlp(_fullFakePath);
+        await using var ytdlp = new Ytdlp("yt-dlp");
 
         var metadata = await ytdlp.GetMetadataAsync(TestVideoUrl);
 
@@ -79,7 +55,7 @@ public class YtdlpIntegrationTests : IDisposable
     {
         Skip.IfNot(RunIntegration, "Set YTDLP_INTEGRATION_TESTS=1 to run integration tests.");
 
-        await using var ytdlp = new Ytdlp(_fullFakePath);
+        await using var ytdlp = new Ytdlp("yt-dlp");
 
         // An invalid URL should either return null or throw a meaningful exception,
         // not hang or crash the host process.
@@ -100,7 +76,7 @@ public class YtdlpIntegrationTests : IDisposable
     {
         Skip.IfNot(RunIntegration, "Set YTDLP_INTEGRATION_TESTS=1 to run integration tests.");
 
-        await using var ytdlp = new Ytdlp(_fullFakePath);
+        await using var ytdlp = new Ytdlp("yt-dlp");
 
         var formats = await ytdlp.GetFormatsAsync(TestVideoUrl);
 
@@ -115,7 +91,7 @@ public class YtdlpIntegrationTests : IDisposable
     {
         Skip.IfNot(RunIntegration, "Set YTDLP_INTEGRATION_TESTS=1 to run integration tests.");
 
-        await using var ytdlp = new Ytdlp(_fullFakePath);
+        await using var ytdlp = new Ytdlp("yt-dlp");
 
         var formatId = await ytdlp.GetBestVideoFormatIdAsync(TestVideoUrl, maxHeight: 720);
 
@@ -127,7 +103,7 @@ public class YtdlpIntegrationTests : IDisposable
     {
         Skip.IfNot(RunIntegration, "Set YTDLP_INTEGRATION_TESTS=1 to run integration tests.");
 
-        await using var ytdlp = new Ytdlp(_fullFakePath);
+        await using var ytdlp = new Ytdlp("yt-dlp");
 
         var formatId = await ytdlp.GetBestAudioFormatIdAsync(TestVideoUrl);
 
@@ -141,7 +117,7 @@ public class YtdlpIntegrationTests : IDisposable
     {
         Skip.IfNot(RunIntegration, "Set YTDLP_INTEGRATION_TESTS=1 to run integration tests.");
 
-        await using var ytdlp = new Ytdlp(_fullFakePath);
+        await using var ytdlp = new Ytdlp("yt-dlp");
 
         var lite = await ytdlp.GetMetadataLiteAsync(
             TestVideoUrl,
@@ -164,7 +140,7 @@ public class YtdlpIntegrationTests : IDisposable
 
         try
         {
-            await using var ytdlp = new Ytdlp(_fullFakePath)
+            await using var ytdlp = new Ytdlp("yt-dlp")
                 .WithSimulate()
                 .WithFormat("best")
                 .WithOutputFolder(outputDir);
@@ -187,7 +163,7 @@ public class YtdlpIntegrationTests : IDisposable
     {
         Skip.IfNot(RunIntegration, "Set YTDLP_INTEGRATION_TESTS=1 to run integration tests.");
 
-        await using var ytdlp = new Ytdlp(_fullFakePath)
+        await using var ytdlp = new Ytdlp("yt-dlp")
             .WithSimulate()
             .WithFormat("best")
             .WithOutputFolder(Path.GetTempPath());


### PR DESCRIPTION
Removed IDisposable and cleanup from test classes for simplicity. Updated integration tests to use "yt-dlp" from PATH. Added a GitHub Actions workflow to automate integration tests with yt-dlp installed.