### PR TITLE
Enable source-gen JSON for Metadata, add YtdlpJsonContext

### DIFF
--- a/src/Ytdlp.NET/Parsing/RegexPatterns.cs
+++ b/src/Ytdlp.NET/Parsing/RegexPatterns.cs
@@ -1,4 +1,6 @@
-﻿namespace ManuHub.Ytdlp.NET;
+﻿using System.Text.Json.Serialization;
+
+namespace ManuHub.Ytdlp.NET;
 
 internal static class RegexPatterns
 {

--- a/src/Ytdlp.NET/Parsing/YtdlpJsonContext.cs
+++ b/src/Ytdlp.NET/Parsing/YtdlpJsonContext.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.Json.Serialization;
+
+namespace ManuHub.Ytdlp.NET;
+
+/// <summary>
+/// Defines the source-generated JSON serialization context for <see cref="Ytdlp"/>.
+/// </summary>
+/// <remarks>
+/// This class enables high-performance, reflection-free JSON serialization/deserialization.
+/// It is essential for:
+/// <list type="bullet">
+/// <item>Reducing CPU overhead and memory allocations during metadata probing.</item>
+/// <item>Supporting Native AOT compilation by providing compile-time type metadata.</item>
+/// </list>
+/// </remarks>
+[JsonSerializable(typeof(Metadata))]
+public partial class YtdlpJsonContext : JsonSerializerContext { }

--- a/src/Ytdlp.NET/Ytdlp.Probe.cs
+++ b/src/Ytdlp.NET/Ytdlp.Probe.cs
@@ -15,7 +15,8 @@ public sealed partial class Ytdlp
     {
         PropertyNameCaseInsensitive = true,
         NumberHandling = JsonNumberHandling.AllowReadingFromString,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        TypeInfoResolver = YtdlpJsonContext.Default
     };
 
     #endregion
@@ -147,7 +148,7 @@ public sealed partial class Ytdlp
 
         try
         {
-            return JsonSerializer.Deserialize<Metadata>(json, JsonOptions);
+            return JsonSerializer.Deserialize(json, YtdlpJsonContext.Default.Metadata);
         }
         catch (Exception ex)
         {
@@ -187,7 +188,7 @@ public sealed partial class Ytdlp
 
         try
         {
-            return JsonSerializer.Deserialize<Metadata>(json, JsonOptions);
+            return JsonSerializer.Deserialize(json, YtdlpJsonContext.Default.Metadata);
         }
         catch (Exception ex)
         {
@@ -208,24 +209,6 @@ public sealed partial class Ytdlp
     /// (non-flattened) metadata, or null if the output is empty.</returns>
     public async Task<string?> GetDeepMetadataRawAsync(string url, CancellationToken ct = default, bool tuneProcess = true)
         => await GetMetadataInternalAsync(url, flat: false, ct, tuneProcess);
-
-    private async Task<string?> GetMetadataInternalAsync(string url, bool flat, CancellationToken ct, bool tuneProcess)
-    {
-        if (string.IsNullOrWhiteSpace(url))
-            throw new ArgumentException("URL cannot be empty.", nameof(url));
-
-        var arguments =
-            "--dump-single-json " +
-            "--simulate " +
-            "--skip-download " +
-            (flat ? "--flat-playlist " : "") +
-            "--lazy-playlist " +
-            "--quiet " +
-            "--no-warnings " +
-            $"{Quote(url)}";
-
-        return await RunProbeAsync(arguments, ct, tuneProcess);
-    }
 
     /// <summary>
     /// Retrieves a list of all available stream formats for a given URL.
@@ -475,6 +458,25 @@ public sealed partial class Ytdlp
             _logger.Log(LogType.Error, $"Probe failed: {ex.Message}");
             return null;
         }
+    }
+
+
+    private async Task<string?> GetMetadataInternalAsync(string url, bool flat, CancellationToken ct, bool tuneProcess)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            throw new ArgumentException("URL cannot be empty.", nameof(url));
+
+        var arguments =
+            "--dump-single-json " +
+            "--simulate " +
+            "--skip-download " +
+            (flat ? "--flat-playlist " : "") +
+            "--lazy-playlist " +
+            "--quiet " +
+            "--no-warnings " +
+            $"{Quote(url)}";
+
+        return await RunProbeAsync(arguments, ct, tuneProcess);
     }
 
     private List<Format> ParseFormats(string result)


### PR DESCRIPTION
Switch to System.Text.Json source-generated serialization for Metadata to improve performance and support Native AOT. Add YtdlpJsonContext with [JsonSerializable] for compile-time metadata. Update deserialization logic and JsonSerializerOptions to use the new context. Includes minor formatting and using directive adjustments.